### PR TITLE
Update `VMState` instantiation on `lambda_vm_adapter`

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -111,6 +111,7 @@ pub fn run_vm(
         entry_address,
         context_val.msg_sender,
         context_val.u128_value,
+        default_aa_code_hash.into(),
     );
 
     if abi_params.is_constructor {


### PR DESCRIPTION
# What ❔

This PR updates the lambda vm adapter to cope with API changes on `VMState` from [this PR.](https://github.com/lambdaclass/era_vm/pull/143)

## Why ❔


## Checklist

* Update `run_vm` function from `lambda_vm_adapter.rs`
