### PR TITLE
feat: Add flag to run tests with 128-bit encoding.

### DIFF
--- a/compiler_tester/src/compiler_tester/arguments.rs
+++ b/compiler_tester/src/compiler_tester/arguments.rs
@@ -113,6 +113,11 @@ pub struct Arguments {
     /// Choose between `build` to compile tests only without running them, and `run` to compile and run them.
     #[structopt(long = "workflow", default_value = "run")]
     pub workflow: Workflow,
+
+    /// Use the alternative encoding for 128 bit long opcodes,
+    /// only available with lambda's era vm.
+    #[structopt(long = "use-test-encoding")]
+    pub test_encoding: bool,
 }
 
 impl Arguments {

--- a/compiler_tester/src/compiler_tester/main.rs
+++ b/compiler_tester/src/compiler_tester/main.rs
@@ -134,9 +134,11 @@ fn main_inner(arguments: Arguments) -> anyhow::Result<()> {
                     arguments.trace as u64,
                 ),
             );
-
             #[cfg(feature = "lambda_vm")]
-            zkevm_assembly::set_encoding_mode(zkevm_assembly::RunningVmEncodingMode::Production);
+            zkevm_assembly::set_encoding_mode(match arguments.test_encoding {
+                true => (zkevm_assembly::RunningVmEncodingMode::Testing),
+                false => (zkevm_assembly::RunningVmEncodingMode::Production),
+            });
             #[cfg(feature = "vm2")]
             zkevm_assembly::set_encoding_mode(zkevm_assembly::RunningVmEncodingMode::Production);
             #[cfg(not(any(feature = "vm2", feature = "lambda_vm")))]
@@ -265,6 +267,7 @@ mod tests {
             llvm_verify_each: false,
             llvm_debug_logging: false,
             workflow: compiler_tester::Workflow::BuildAndRun,
+            test_encoding: false,
         };
 
         crate::main_inner(arguments).expect("Manual testing failed");

--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -12,9 +12,9 @@ use lambda_vm;
 use lambda_vm::state::VMState;
 use lambda_vm::store::initial_decommit;
 use lambda_vm::store::InMemory;
+use lambda_vm::store::Storage;
 use lambda_vm::value::TaggedValue;
 use lambda_vm::ExecutionOutput;
-use lambda_vm::store::Storage;
 use web3::types::H160;
 use zkevm_assembly::Assembly;
 use zkevm_opcode_defs::ethereum_types::{H256, U256};
@@ -135,7 +135,14 @@ pub fn run_vm(
         TaggedValue::new_raw_integer(abi_params.r5_value.unwrap_or_default()),
     );
 
-    let (result, final_vm) = lambda_vm::run_program_with_custom_bytecode(vm, &mut storage);
+    let (result, final_vm) = match zkevm_assembly::get_encoding_mode() {
+        zkevm_assembly::RunningVmEncodingMode::Testing => {
+            lambda_vm::run_program_with_test_encode(vm, &mut storage)
+        }
+        zkevm_assembly::RunningVmEncodingMode::Production => {
+            lambda_vm::run_program_with_custom_bytecode(vm, &mut storage)
+        }
+    };
     let events = merge_events(&final_vm.events);
     let output = match result {
         ExecutionOutput::Ok(output) => Output {
@@ -157,9 +164,15 @@ pub fn run_vm(
 
     for (key, value) in storage.state_storage.into_iter() {
         if initial_storage.storage_read(key).unwrap() != Some(value) {
-            let mut bytes: [u8; 32] = [0;32];
+            let mut bytes: [u8; 32] = [0; 32];
             value.to_big_endian(&mut bytes);
-            storage_changes.insert(StorageKey{address: key.address, key: key.key}, H256::from(bytes));
+            storage_changes.insert(
+                StorageKey {
+                    address: key.address,
+                    key: key.key,
+                },
+                H256::from(bytes),
+            );
         }
     }
 


### PR DESCRIPTION
# What ❔
- Simple boolean flag that makes it possible to make the compiler tester use 128bit long opcodes.

## Why ❔

- Some tests require them to pass.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
