### PR TITLE
Fix `bytecode_to_hash` on `lambda_vm_adapter.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,12 +656,10 @@ dependencies = [
 name = "era_vm"
 version = "0.1.0"
 dependencies = [
- "ethabi",
  "hex",
  "lazy_static",
  "primitive-types",
  "rocksdb",
- "serde_json",
  "thiserror",
  "zk_evm_abstractions 1.5.1",
  "zkevm_opcode_defs 1.5.0 (git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.5.1)",


### PR DESCRIPTION
# What ❔

This PR fixes `complex/parser` failing tests after the `evm-interpreter` merge by updating how bytecode hash is calculated on `lambda_vm_adapter.rs`

## Why ❔

## Checklist
