### PR TITLE
Add initial gas to VmState

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -144,6 +144,7 @@ pub fn run_vm(
         evm_interpreter_code_hash.into(),
         0,
         false,
+        u32::MAX - 0x80000000,
     );
 
     if abi_params.is_constructor {


### PR DESCRIPTION
# What ❔

Adds necessary changes to integrate the lambda adapter with the new changes for integrating the era_vm with zksync-era tests. Merge once this [pr](https://github.com/lambdaclass/era_vm/pull/191) gets merged into main.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
