### PR TITLE
Add decommited_hashes to lambda adapter

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -18,6 +18,7 @@ use lambda_vm::value::TaggedValue;
 use lambda_vm::vm::ExecutionOutput;
 use lambda_vm::EraVM;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::rc::Rc;
 use web3::types::H160;
 use zkevm_assembly::zkevm_opcode_defs::decoding::{EncodingModeProduction, EncodingModeTesting};
@@ -122,12 +123,13 @@ pub fn run_vm(
     let initial_storage = InitialStorageMemory {
         initial_storage: lambda_storage,
     };
-    let contract_storage = ContractStorageMemory {
+    let mut contract_storage = ContractStorageMemory {
         contract_storage: lambda_contract_storage,
+        decommited_hashes: HashSet::new(),
     };
     let initial_program = initial_decommit(
         &initial_storage,
-        &contract_storage,
+        &mut contract_storage,
         entry_address,
         evm_interpreter_code_hash.into(),
     )?;


### PR DESCRIPTION
# What ❔

Adds decommited_hashes to lambda adapter. Merge this once [this pr](https://github.com/lambdaclass/era_vm/pull/193) gets merged.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
