### PR TITLE
Adapt zksync-era-tests

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -139,6 +139,7 @@ pub fn run_vm(
         evm_interpreter_code_hash.into(),
         0,
         false,
+        u32::MAX - 0x80000000,
     );
 
     if abi_params.is_constructor {


### PR DESCRIPTION
# What ❔
Adapts the `compiler-tester` to the new changes needed for adapting `era_vm` with zksync-era tests. See `era_vm` changes [here](https://github.com/lambdaclass/era_vm/pull/201)

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
