### PR TITLE
Lambda adapter update

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -135,10 +135,11 @@ pub fn run_vm(
         entry_address,
         context_val.msg_sender,
         context_val.u128_value,
-        default_aa_code_hash.into(),
-        evm_interpreter_code_hash.into(),
+        default_aa_code_hash,
+        evm_interpreter_code_hash,
         0,
         false,
+        u32::MAX - 0x80000000,
     );
 
     if abi_params.is_constructor {


### PR DESCRIPTION
# What ❔

This PR updates `Execution` instantiation on `lambda_vm_adapter.rs` following changes made on [this era vm PR
](https://github.com/lambdaclass/era_vm/pull/210).

Depends on [this era vm PR](https://github.com/lambdaclass/era_vm/pull/210). Shouldn't be merged until this dependency is merged.

## Why ❔

## Checklist
