### PR TITLE
Refactor lambda_vm_adapter to new tracer implementation

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -168,10 +168,10 @@ pub fn run_vm(
     let mut blob_tracer = BlobSaverTracer::new();
     let result = match zkevm_assembly::get_encoding_mode() {
         zkevm_assembly::RunningVmEncodingMode::Testing => {
-            era_vm.run_program_with_test_encode_and_tracer(Some(&mut blob_tracer))
+            era_vm.run_program_with_test_encode_and_tracer(&mut blob_tracer)
         }
         zkevm_assembly::RunningVmEncodingMode::Production => {
-            era_vm.run_program_with_custom_bytecode_and_tracer(Some(&mut blob_tracer))
+            era_vm.run_program_with_custom_bytecode_and_tracer(&mut blob_tracer)
         }
     };
     let events = merge_events(&era_vm.state.events());

--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -168,10 +168,10 @@ pub fn run_vm(
     let mut blob_tracer = BlobSaverTracer::new();
     let result = match zkevm_assembly::get_encoding_mode() {
         zkevm_assembly::RunningVmEncodingMode::Testing => {
-            era_vm.run_program_with_test_encode(Some(&mut blob_tracer))
+            era_vm.run_program_with_test_encode_and_tracer(Some(&mut blob_tracer))
         }
         zkevm_assembly::RunningVmEncodingMode::Production => {
-            era_vm.run_program_with_custom_bytecode(Some(&mut blob_tracer))
+            era_vm.run_program_with_custom_bytecode_and_tracer(Some(&mut blob_tracer))
         }
     };
     let events = merge_events(&era_vm.state.events());


### PR DESCRIPTION
# What ❔

Adapts the `lambda_vm_adapter` to the new implementation of tracers. See [here](https://github.com/lambdaclass/era_vm/pull/212).

## Why ❔

To be able to run the compiler-tester on `era_vm`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
