### PR TITLE
Adapt to zk server

### DIFF
--- a/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
+++ b/compiler_tester/src/vm/eravm/lambda_vm_adapter.rs
@@ -166,14 +166,14 @@ pub fn run_vm(
         TaggedValue::new_raw_integer(abi_params.r5_value.unwrap_or_default()),
     );
 
-    let mut era_vm = EraVM::new(vm, Rc::new(RefCell::new(storage.clone())));
+    let mut era_vm = EraVM::new(vm);
     let mut blob_tracer = BlobSaverTracer::new();
     let result = match zkevm_assembly::get_encoding_mode() {
         zkevm_assembly::RunningVmEncodingMode::Testing => {
-            era_vm.run_program_with_test_encode_and_tracer(&mut blob_tracer)
+            era_vm.run_program_with_test_encode_and_tracer(&mut blob_tracer, &mut storage)
         }
         zkevm_assembly::RunningVmEncodingMode::Production => {
-            era_vm.run_program_with_custom_bytecode_and_tracer(&mut blob_tracer)
+            era_vm.run_program_with_custom_bytecode_and_tracer(&mut blob_tracer,  &mut storage)
         }
     };
     let events = merge_events(&era_vm.state.events());


### PR DESCRIPTION
# What ❔
This PR adapts compiler tester to the new changes in era vm needed for zksync-era integration

Related to:

https://github.com/lambdaclass/era_vm/pull/221
https://github.com/lambdaclass/zksync-era/pull/253
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
